### PR TITLE
Add o_as_suffix option

### DIFF
--- a/segtypes/bin.py
+++ b/segtypes/bin.py
@@ -20,7 +20,7 @@ class N64SegBin(N64Segment):
         lines = []
         lines.append("    /* 0x00000000 {:X}-{:X} [{:X}] */".format(self.rom_start, self.rom_end, self.rom_end - self.rom_start))
         lines.append("    {} 0x{:X} : AT(0x{:X}) ".format(section_name, self.rom_start, self.rom_start) + "{")
-        if self.options.get("o_as_suffix", False):
+        if not self.options.get("ld_o_replace_extension", True):
             lines.append("        build/bin/{}.bin.o(.data);".format(self.name))
         else:
             lines.append("        build/bin/{}.o(.data);".format(self.name))

--- a/segtypes/bin.py
+++ b/segtypes/bin.py
@@ -20,7 +20,10 @@ class N64SegBin(N64Segment):
         lines = []
         lines.append("    /* 0x00000000 {:X}-{:X} [{:X}] */".format(self.rom_start, self.rom_end, self.rom_end - self.rom_start))
         lines.append("    {} 0x{:X} : AT(0x{:X}) ".format(section_name, self.rom_start, self.rom_start) + "{")
-        lines.append("        build/bin/{}.o(.data);".format(self.name))
+        if self.options.get("o_as_suffix", False):
+            lines.append("        build/bin/{}.bin.o(.data);".format(self.name))
+        else:
+            lines.append("        build/bin/{}.o(.data);".format(self.name))
         lines.append("    }")
         lines.append("")
         lines.append("")

--- a/segtypes/code.py
+++ b/segtypes/code.py
@@ -493,7 +493,7 @@ class N64SegCode(N64Segment):
             subdir = self.get_subdir(split_file["subtype"])
             section_name2 = self.get_sect_name_2(split_file["subtype"], section_name)
 
-            if self.options.get("o_as_suffix", False):
+            if not self.options.get("ld_o_replace_extension", True):
                 ret.append("        build/{}/{}.{}.o({});".format(subdir, split_file["name"], self.get_ext(split_file["subtype"]), section_name2))
             else:
                 ret.append("        build/{}/{}.o({});".format(subdir, split_file["name"], section_name2))

--- a/segtypes/code.py
+++ b/segtypes/code.py
@@ -376,7 +376,7 @@ class N64SegCode(N64Segment):
                 funcs_text = self.add_labels(funcs)
 
                 if split_file["subtype"] == "c":
-                    c_path = os.path.join(base_path, "src", split_file["name"] + "." + self.get_exit(split_file["subtype"]))
+                    c_path = os.path.join(base_path, "src", split_file["name"] + "." + self.get_ext(split_file["subtype"]))
 
                     if os.path.exists(c_path):
                         defined_funcs = get_funcs_defined_in_c(c_path)
@@ -397,7 +397,7 @@ class N64SegCode(N64Segment):
                             out_lines.extend(funcs_text[func][0])
                             out_lines.append("")
 
-                            outpath = Path(os.path.join(out_dir, split_file["name"], func_name + "." + self.get_exit(split_file["subtype"])))
+                            outpath = Path(os.path.join(out_dir, split_file["name"], func_name + ".s"))
                             outpath.parent.mkdir(parents=True, exist_ok=True)
 
                             with open(outpath, "w", newline="\n") as f:
@@ -440,7 +440,7 @@ class N64SegCode(N64Segment):
             elif split_file["subtype"] == "bin" and ("bin" in self.options["modes"] or "all" in self.options["modes"]):
                 out_dir = self.create_split_dir(base_path, "bin")
 
-                bin_path = os.path.join(out_dir, split_file["name"] + "." + self.get_exit(split_file["subtype"]))
+                bin_path = os.path.join(out_dir, split_file["name"] + "." + self.get_ext(split_file["subtype"]))
                 Path(bin_path).parent.mkdir(parents=True, exist_ok=True)
                 with open(bin_path, "wb") as f:
                     f.write(rom_bytes[split_file["start"] : split_file["end"]])

--- a/segtypes/header.py
+++ b/segtypes/header.py
@@ -53,7 +53,7 @@ class N64SegHeader(N64Segment):
         lines = []
         lines.append("    /* 0x00000000 {:X}-{:X} [{:X}] */".format(self.rom_start, self.rom_end, self.rom_end - self.rom_start))
         lines.append("    {} 0x{:X} : AT(0x{:X}) ".format(section_name, self.rom_start, self.rom_start) + "{")
-        if self.options.get("o_as_suffix", False):
+        if not self.options.get("ld_o_replace_extension", True):
             lines.append("        build/asm/{}.s.o(.data);".format(self.name))
         else:
             lines.append("        build/asm/{}.o(.data);".format(self.name))

--- a/segtypes/header.py
+++ b/segtypes/header.py
@@ -53,7 +53,10 @@ class N64SegHeader(N64Segment):
         lines = []
         lines.append("    /* 0x00000000 {:X}-{:X} [{:X}] */".format(self.rom_start, self.rom_end, self.rom_end - self.rom_start))
         lines.append("    {} 0x{:X} : AT(0x{:X}) ".format(section_name, self.rom_start, self.rom_start) + "{")
-        lines.append("        build/asm/{}.o(.data);".format(self.name))
+        if self.options.get("o_as_suffix", False):
+            lines.append("        build/asm/{}.s.o(.data);".format(self.name))
+        else:
+            lines.append("        build/asm/{}.o(.data);".format(self.name))
         lines.append("    }")
         lines.append("")
         lines.append("")


### PR DESCRIPTION
Causes ld scripts to link `.s` as `.s.o` rather than just `.o` for example