### PR TITLE
Remove ld_addrs.h generation

### DIFF
--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -85,7 +85,9 @@ class N64Segment:
 
         s = (
             f"/* 0x{self.vram_addr:08X} {self.rom_start:X}-{self.rom_end:X} (len {self.rom_length:X}) */\n"
-            f".{sect_name} 0x{vram_or_rom:X} : AT(0x{self.rom_start:X}) {{\n"
+            f"{sect_name}_ROM_START = __romPos;\n"
+            f"{sect_name}_VRAM = ADDR(.{sect_name});\n"
+            f".{sect_name} 0x{vram_or_rom:X} : AT({sect_name}_ROM_START) {{\n"
         )
 
         for subdir, path, obj_type in self.get_ld_files():
@@ -95,13 +97,13 @@ class N64Segment:
 
             s += f"    BUILD_DIR/{path}({obj_type});\n"
 
-        s += "}\n"
+        s += (
+            "}\n"
+            f"{sect_name}_ROM_END = __romPos + SIZEOF(.{sect_name});\n"
+            f"__romPos += SIZEOF(.{sect_name});\n"
+        )
 
-        return s, {
-            f"{sect_name}_ROM_START": self.rom_start,
-            f"{sect_name}_ROM_END": self.rom_end,
-            f"{sect_name}_VRAM": vram_or_rom,
-        }
+        return s
 
     def get_ld_section_name(self):
         return f"data_{self.rom_start:X}"


### PR DESCRIPTION
`ld_addrs.h` can be trivially generated using the below Makefile target, so it's not needed in splat anymore.

```Makefile
include/ld_addrs.h: $(BUILD_DIR)/$(LD_SCRIPT)
	grep -E "[^ ]+ =" $< -o | sed 's/^/extern void* /; s/ =/;/' > $@
```

---

This commit also improves ld script output to look like this, which is admittedly harder to read*:

```
    /* 0xA4000040 40-1000 (len FC0) */
    code_boot_ROM_START = __romPos;
    code_boot_VRAM = ADDR(.code_boot);
    .code_boot 0xA4000040 : AT(code_boot_ROM_START) {
        BUILD_DIR/asm/boot.s.o(.text);
        BUILD_DIR/bin/bootcode_font.bin.o(.data);
    }
    code_boot_ROM_END = __romPos + SIZEOF(.code_boot);
    __romPos += SIZEOF(.code_boot);
```

This improves shiftability by not hardcoding ROM_START and ROM_END for each segment - only the VRAM address. This means if a segment changes size for whatever reason, everything below it will get shifted down rather than having conflicting segments overwriting eachother.

`__romPos` isn't a novel concept - the macros in the SM64 decomp linker script expand to something very similar.

(* who the hell is reading linker script output anyway? :shipit:)