### PR TITLE
Add arguments for non-ASCII encoding in header

### DIFF
--- a/segtypes/header.py
+++ b/segtypes/header.py
@@ -21,6 +21,9 @@ class N64SegHeader(N64Segment):
     def split(self, rom_bytes, base_path):
         out_dir = self.create_split_dir(base_path, "asm")
 
+        if self.options.get("header_encoding", "ASCII"):
+            encoding = self.options.get("header_encoding", "ASCII")
+
         header_lines = []
         header_lines.append(f".section .{self.name}, \"a\"\n")
         header_lines.append(self.get_line("word", rom_bytes[0x00:0x04], "PI BSB Domain 1 register"))
@@ -31,7 +34,7 @@ class N64SegHeader(N64Segment):
         header_lines.append(self.get_line("word", rom_bytes[0x14:0x18], "Checksum 2"))
         header_lines.append(self.get_line("word", rom_bytes[0x18:0x1C], "Unknown 1"))
         header_lines.append(self.get_line("word", rom_bytes[0x1C:0x20], "Unknown 2"))
-        header_lines.append(".ascii \"" + rom_bytes[0x20:0x34].decode("ASCII").strip().ljust(20) + "\" /* Internal name */")
+        header_lines.append(".ascii \"" + rom_bytes[0x20:0x34].decode(encoding).strip().ljust(20) + "\" /* Internal name */")
         header_lines.append(self.get_line("word", rom_bytes[0x34:0x38], "Unknown 3"))
         header_lines.append(self.get_line("word", rom_bytes[0x38:0x3C], "Cartridge"))
         header_lines.append(self.get_line("ascii", rom_bytes[0x3C:0x3E], "Cartridge ID"))

--- a/segtypes/header.py
+++ b/segtypes/header.py
@@ -21,8 +21,7 @@ class N64SegHeader(N64Segment):
     def split(self, rom_bytes, base_path):
         out_dir = self.create_split_dir(base_path, "asm")
 
-        if self.options.get("header_encoding", "ASCII"):
-            encoding = self.options.get("header_encoding", "ASCII")
+        encoding = self.options.get("header_encoding", "ASCII")
 
         header_lines = []
         header_lines.append(f".section .{self.name}, \"a\"\n")

--- a/util/rominfo.py
+++ b/util/rominfo.py
@@ -72,7 +72,7 @@ def get_info_bytes(rom_bytes, encoding):
         name = rom_bytes[0x20:0x34].decode(encoding).strip()
     except:
         print("n64splat could not decode the game name, try using a different encoding by passing the --encoding argument (see docs.python.org/2.4/lib/standard-encodings.html for valid encodings)")
-        exit()
+        exit(1)
 
     country_code = rom_bytes[0x3E]
 


### PR DESCRIPTION
This is a fix for issue #46, tried to keep everything as simple as possible, for splits with split.py one can add "header_encoding: ENC_TYPE" to options in the .yaml file, for rominfo.py one can pass --encoding ENC_TYPE, all of these will default to ASCII if no encoding type is provided.